### PR TITLE
window bug fixes

### DIFF
--- a/src/core/run.cpp
+++ b/src/core/run.cpp
@@ -1,6 +1,7 @@
 #include "run.h"
 
 #include <iostream>
+#include <limits>
 
 extern "C" {
 #include "lua.h"
@@ -52,9 +53,15 @@ static int error_handler(lua_State* L) {
 }
 
 static void print_runtime_error(const char* err) {
+	// Minimize window before displaying the error and locking the event loop.
+	// This basically avoids locking the game down, which is super frusterating when throwing an error when in fullscreen mode.
+	// This also makes it very convenient when an error is thrown because the game is moved out of the way of the console :)
+	window->minimize();
 	std::cout << "RUNTIME ERROR: " << err << std::endl << std::endl;
 	std::cout << "Press enter to continue execution..." << std::endl;
-	int _ = std::getchar(); // Wait for user input before continuing execution
+	// Ignore all characters other than newline
+	std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+	window->restore();
 }
 
 static bool init() {

--- a/src/window/Window.h
+++ b/src/window/Window.h
@@ -14,6 +14,8 @@ namespace milk {
 		virtual void size(int width, int height) = 0;
 		virtual bool fullscreen() const = 0;
 		virtual void fullscreen(bool toggle) = 0;
+		virtual void minimize() = 0;
+		virtual void restore() = 0;
 		virtual void close() = 0;
 	};
 }

--- a/src/window/sdl/SDLWindow.cpp
+++ b/src/window/sdl/SDLWindow.cpp
@@ -4,6 +4,12 @@
 
 #include "SDL.h"
 
+static const int DEFAULT_WIDTH = 800;
+static const int DEFAULT_HEIGHT = 600;
+
+// We define this bad boi here because SDL does not, and we don't want magic numbers chilling up in this boi, son.
+static const int MILK_SDL_WINDOW_NO_FLAG = 0;
+
 milk::SDLWindow::SDLWindow()
 	: m_handle{ nullptr }
 	, m_shouldClose{ false } { }
@@ -16,7 +22,7 @@ bool milk::SDLWindow::init() {
 
 	// We create a hidden window that must be explicitly shown via show()
 	// This is done in order to give lua a chance to change the window settings before showing it.
-	m_handle = SDL_CreateWindow("milk", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 800, 600, SDL_WINDOW_HIDDEN);
+	m_handle = SDL_CreateWindow("milk", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, DEFAULT_WIDTH, DEFAULT_HEIGHT, SDL_WINDOW_HIDDEN);
 	if (m_handle == nullptr) {
 		std::cout << "Error creating SDL_Window: " << SDL_GetError() << std::endl;
 		return false;

--- a/src/window/sdl/SDLWindow.cpp
+++ b/src/window/sdl/SDLWindow.cpp
@@ -6,9 +6,7 @@
 
 milk::SDLWindow::SDLWindow()
 	: m_handle{ nullptr }
-	, m_shouldClose{ false }
-	, m_width{ 800 }
-	, m_height{ 600 } { }
+	, m_shouldClose{ false } { }
 
 bool milk::SDLWindow::init() {
 	if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) < 0) {
@@ -18,7 +16,7 @@ bool milk::SDLWindow::init() {
 
 	// We create a hidden window that must be explicitly shown via show()
 	// This is done in order to give lua a chance to change the window settings before showing it.
-	m_handle = SDL_CreateWindow("milk", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, m_width, m_height, SDL_WINDOW_HIDDEN);
+	m_handle = SDL_CreateWindow("milk", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 800, 600, SDL_WINDOW_HIDDEN);
 	if (m_handle == nullptr) {
 		std::cout << "Error creating SDL_Window: " << SDL_GetError() << std::endl;
 		return false;
@@ -41,33 +39,31 @@ std::tuple<int, int> milk::SDLWindow::size() const {
 }
 
 void milk::SDLWindow::size(int width, int height) {
-	m_width = width;
-	m_height = height;
 	SDL_SetWindowSize(m_handle, width, height);
 	SDL_SetWindowPosition(m_handle, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
 
 bool milk::SDLWindow::fullscreen() const {
-	return (SDL_GetWindowFlags(m_handle) & SDL_WINDOW_FULLSCREEN) == SDL_WINDOW_FULLSCREEN;
+	return (SDL_GetWindowFlags(m_handle) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP;
 }
 
 void milk::SDLWindow::fullscreen(const bool toggle) {
-	if (toggle == fullscreen()) {
-		return;
+	if (toggle != fullscreen()) {
+		if (toggle) {
+			SDL_SetWindowFullscreen(m_handle, SDL_WINDOW_FULLSCREEN_DESKTOP);
+		}
+		else {
+			SDL_SetWindowFullscreen(m_handle, MILK_SDL_WINDOW_NO_FLAG);
+		}
 	}
+}
 
-	if (toggle) {
-		int displayIndex = SDL_GetWindowDisplayIndex(m_handle);
-		SDL_Rect displayBounds;
-		SDL_GetDisplayBounds(displayIndex, &displayBounds);
-		SDL_SetWindowSize(m_handle, displayBounds.w, displayBounds.h);
-		SDL_SetWindowFullscreen(m_handle, SDL_WINDOW_FULLSCREEN);
-	}
-	else {
-		SDL_SetWindowFullscreen(m_handle, MILK_SDL_WINDOW_NO_FLAG);
-		SDL_SetWindowSize(m_handle, m_width, m_height);
-		SDL_SetWindowPosition(m_handle, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
-	}
+void milk::SDLWindow::minimize() {
+	SDL_MinimizeWindow(m_handle);
+}
+
+void milk::SDLWindow::restore() {
+	SDL_RestoreWindow(m_handle);
 }
 
 void milk::SDLWindow::show() {

--- a/src/window/sdl/SDLWindow.h
+++ b/src/window/sdl/SDLWindow.h
@@ -23,6 +23,8 @@ namespace milk
 		void size(int width, int height) override;
 		bool fullscreen() const override;
 		void fullscreen(bool toggle) override;
+		void minimize() override;
+		void restore() override;
 		void show();
 		void close() override;
 		bool shouldClose() const;
@@ -32,8 +34,6 @@ namespace milk
 	private:
 		SDL_Window* m_handle;
 		bool m_shouldClose;
-		int m_width;
-		int m_height;
 	};
 }
 

--- a/src/window/sdl/SDLWindow.h
+++ b/src/window/sdl/SDLWindow.h
@@ -1,9 +1,6 @@
 #ifndef _SDL_WINDOW_H_
 #define _SDL_WINDOW_H_
 
-// We define this bad boi here because SDL does not, and we don't want magic numbers chilling up in this boi.
-#define MILK_SDL_WINDOW_NO_FLAG 0
-
 #include <string>
 
 #include "window/Window.h"


### PR DESCRIPTION
I switched milk to use "fake" fullscreen mode, which is basically just a borderless window. Now we don't force the os to change video modes when toggling fullscreen, which was causing odd resolution issues.

I also "fixed" the issue where throwing an error when in fullscreen mode would completely lock the game, forcing you to either shutdown or sign out lol. Now, when an error is thrown, the window is minimized. When done reading the error, the window is restored back to it's previous state.